### PR TITLE
Add email capture and redirect in hero section

### DIFF
--- a/hero-section.html
+++ b/hero-section.html
@@ -200,10 +200,11 @@
         <p class="c360-desc">
           Create, market & sell your courses effortlessly with Course Creator 360.
         </p>
-        <form class="c360-form" onsubmit="return false;">
+        <form class="c360-form" id="hero-email-form">
           <input
             class="c360-input"
             type="email"
+            id="hero-email"
             required
             placeholder="Enter your email*"
           >
@@ -221,4 +222,22 @@
       ></iframe>
     </div>
   </section>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const heroForm = document.getElementById('hero-email-form');
+      if (heroForm) {
+        heroForm.addEventListener('submit', function(e) {
+          e.preventDefault();
+          const email = document.getElementById('hero-email').value.trim();
+          const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+          if (!emailRegex.test(email)) {
+            alert('Please enter a valid email address.');
+            return;
+          }
+          const checkoutUrl = 'https://checkout.coursecreator360.com/b/dR6cNB7Im6N85IA9AF?prefilled_email=' + encodeURIComponent(email);
+          window.location.href = checkoutUrl;
+        });
+      }
+    });
+  </script>
 </div>


### PR DESCRIPTION
## Summary
- update hero section form markup
- validate email input and redirect to checkout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a68119db88328965d74a9ee6af68c

## Summary by Sourcery

Add email capture functionality to the hero section form and redirect users to the checkout page with their email prefilled

New Features:
- Capture user email in the hero section and redirect to checkout with the email prefilled

Enhancements:
- Assign IDs to the hero form and email input for scripting purposes